### PR TITLE
new param: set_vault_addr

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ./run_build.sh
     plugins:
-      - planetscale/vault-oidc-auth#v1.0.1:
+      - planetscale/vault-oidc-auth#v1.1.0:
           vault_addr: "https://my-vault-server"  # required.
           path: auth/buildkite                   # optional. default "auth/buildkite"
           role: some-role                        # optional. default "$BUILDKITE_PIPELINE_SLUG"
           audience: vault                        # optional. default "vault"
           env_prefix: DEV_                       # optional. default "". (prefix to add to VAULT_TOKEN env var name)
+          set_vault_addr: false                  # optional. default "true". (set VAULT_ADDR env var to the value of 'vault_addr')
 ```
 
-If authentication is successful a `VAULT_TOKEN` is added to the environment.
+If authentication is successful a `VAULT_TOKEN` is added to the environment, as
+well as `VAULT_ADDR` if `set_vault_addr` is true.
 
 Setting the `env_prefix` will add a prefix to the `VAULT_TOKEN` environment variable.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,13 @@ services:
       - 'shellcheck /plugin/hooks/*'
 
   lint-plugin:
-    image: buildkite/plugin-linter
+    image: buildkite/plugin-linter:v2.0.2
     volumes:
       - ".:/plugin:ro"
     command:
       - --id=planetscale/vault-oidc-auth
 
   tests:
-    image: buildkite/plugin-tester
+    image: buildkite/plugin-tester:v4.0.0
     volumes:
       - ".:/plugin:ro"

--- a/hooks/environment
+++ b/hooks/environment
@@ -14,6 +14,7 @@ main() {
   local role="${BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_ROLE:-$BUILDKITE_PIPELINE_SLUG}"
   local audience="${BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_AUDIENCE:-vault}"
   local prefix="${BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_ENV_PREFIX:-}"
+  local set_vault_addr="${BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_SET_VAULT_ADDR:-true}"
 
   local jwt vault_token
 
@@ -33,6 +34,10 @@ main() {
   )
   echo -e "~~~ :vault: ${brown}Vault OIDC Auth Plugin${reset}: ${green}OK${reset}: ${prefix}VAULT_TOKEN added to the environment."
   export "${prefix}VAULT_TOKEN"="$vault_token"
+
+  if [[ "$set_vault_addr" =~ ^(true|1|yes)$ ]]; then
+    export "${prefix}VAULT_ADDR"="$addr"
+  fi
 }
 
 main "$@"

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,8 @@ configuration:
       type: string
     env_prefix:
       type: string
+    set_vault_addr:
+      type: boolean
   required:
     - vault_addr
   additionalProperties: false

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -38,6 +38,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_PATH="auth/jwt"
   export BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_ROLE="bar"
   export BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_AUDIENCE="my-aud"
+  export BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_SET_VAULT_ADDR="false"
 
   stub buildkite-agent \
     'oidc request-token --audience my-aud : echo eyJfoobar'
@@ -48,6 +49,7 @@ load '/usr/local/lib/bats/load.bash'
   run bash -c "source $PWD/hooks/environment && env"
   assert_success
   assert_output --partial "VAULT_TOKEN=s.mocktoken"
+  refute_output --regexp "^VAULT_ADDR=http://vault:8200$"
 
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_VAULT_ADDR
@@ -60,6 +62,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PIPELINE_SLUG="foo"
   export BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_VAULT_ADDR="http://vault:8200"
   export BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_ENV_PREFIX="FOO_"
+  export BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_SET_VAULT_ADDR="true"
 
   stub buildkite-agent \
     'oidc request-token --audience vault : echo eyJfoobar'
@@ -70,8 +73,10 @@ load '/usr/local/lib/bats/load.bash'
   run bash -c "source $PWD/hooks/environment && env"
   assert_success
   assert_output --partial "FOO_VAULT_TOKEN=s.mocktoken"
+  assert_output --partial "FOO_VAULT_ADDR=http://vault:8200"
 
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_VAULT_ADDR
   unset BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_ENV_PREFIX
+  unset BUILDKITE_PLUGIN_VAULT_OIDC_AUTH_SET_VAULT_ADDR
 }


### PR DESCRIPTION
If set (default: true), the `VAULT_ADDR` environment variable will be added to the environment for use by downstream plugins or step commands. The value used is taken from the `vault_addr` parameter.