### PR TITLE
Include pipeline_slug in validated claims in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ vault write auth/buildkite/role/my-repo -<<EOF
   "policies": ["default"],
   "user_claim": "pipeline_slug",
   "bound_claims": {
-    "organization_id": ["ORG_ID_GOES_HERE"]
+    "organization_id": ["ORG_ID_GOES_HERE"],
+    "pipeline_slug": "my-repo"
   },
   "role_type": "jwt",
   "token_type": "batch",


### PR DESCRIPTION
The README is missing the `pipeline_slug` in the list of bound claims, allowing pipelines to impersonate each other. This now matches the way we actually use the plugin.

Related to #29.